### PR TITLE
Bind requestHandler function to preserve 'this' context when the function is called.

### DIFF
--- a/src/routers/MsTeamsApiRouter.ts
+++ b/src/routers/MsTeamsApiRouter.ts
@@ -81,7 +81,7 @@ export default (components: any): Router => {
             } else if (component["__isOutgoingWebhook"]) {
                 log(`Creating a new outgoing webhook instance at ${component.__serviceEndpoint}`);
                 const outgoingWebhook: IOutgoingWebhook = new component();
-                router.post(component.__serviceEndpoint, outgoingWebhook.requestHandler);
+                router.post(component.__serviceEndpoint, outgoingWebhook.requestHandler.bind(outgoingWebhook));
             } else if (component["__isConnector"]) {
                 log(`Creating a new connector instance at ${component.__connectEndpoint}`);
                 const connector: IConnector = new component();

--- a/src/routers/MsTeamsApiRouter.ts
+++ b/src/routers/MsTeamsApiRouter.ts
@@ -81,7 +81,9 @@ export default (components: any): Router => {
             } else if (component["__isOutgoingWebhook"]) {
                 log(`Creating a new outgoing webhook instance at ${component.__serviceEndpoint}`);
                 const outgoingWebhook: IOutgoingWebhook = new component();
-                router.post(component.__serviceEndpoint, outgoingWebhook.requestHandler.bind(outgoingWebhook));
+                router.post(component.__serviceEndpoint, (req, res, next) => {
+                    outgoingWebhook.requestHandler(req, res, next);
+                });
             } else if (component["__isConnector"]) {
                 log(`Creating a new connector instance at ${component.__connectEndpoint}`);
                 const connector: IConnector = new component();


### PR DESCRIPTION
This fixes an issue where the function passed to `router.post` is no longer aware of the `this` context. and `this` inside the `requestHandler` function will be undefined.

Indirectly related to this: https://stackoverflow.com/questions/34680450/this-is-undefined-in-expressjs-route-handler.

Another solution would be to replace the method reference with a lambda method. e.g.
``` javascript
router.post(component.__serviceEndpoint, (res, req, next) => outgoingWebhook.requestHandler(res, req, next));
```
This would also preserve the `this` context inside the `requestHandler` method.